### PR TITLE
Don't run as root

### DIFF
--- a/2_create_project/conf/privilege
+++ b/2_create_project/conf/privilege
@@ -1,0 +1,41 @@
+{
+  "username": "gitea",
+  "groupname": "gitea",
+  "ctrl-script": [{
+      "action": "preinst",
+      "run-as": "root"
+    },
+    {
+      "action": "postinst",
+      "run-as": "root"
+    },
+    {
+      "action": "preuninst",
+      "run-as": "root"
+    },
+    {
+      "action": "postuninst",
+      "run-as": "root"
+    },
+    {
+      "action": "preupgrade",
+      "run-as": "root"
+    },
+    {
+      "action": "postupgrade",
+      "run-as": "root"
+    },
+    {
+      "action": "start",
+      "run-as": "package"
+    },
+    {
+      "action": "stop",
+      "run-as": "root"
+    },
+    {
+      "action": "status",
+      "run-as": "root"
+    }
+  ]
+}

--- a/2_create_project/scripts/start-stop-status
+++ b/2_create_project/scripts/start-stop-status
@@ -11,15 +11,15 @@ DNAME="Gitea"
 INSTALL_DIR="/usr/local/${PACKAGE}"
 DIR_gitea="${INSTALL_DIR}/gitea"
 gitea="${DIR_gitea}/gitea"
-PID_FILE="/var/run/gitea.pid"
-LOG_FILE="/var/log/gitea.log"
+PID_FILE="${DIR_gitea}/gitea.pid"
+LOG_FILE="${DIR_gitea}/gitea.log"
 
 FILE_CREATE_LOG="${DIR_gitea}/wizard_create_log"
 
 export HOME=${DIR_gitea}
 #export PATH=$PATH:~/opt/bin  # to Git. Not necessary with Git Server (Synology)
-export USER=root
-export USERNAME=root
+export USER=gitea
+export USERNAME=gitea
 
 start_daemon ()
 {


### PR DESCRIPTION
gitea should not be run as root. With this change the package installer creates a specific gitea:gitea user/group when necessary and gitea is run under this user. Uninstalling does not (yet) remove the user.