### PR TITLE
Ensure the gitea executable has its executable bit set

### DIFF
--- a/create_spk.sh
+++ b/create_spk.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+chmod +x 1_create_package/gitea/gitea
 cd 1_create_package 
 tar cvfz package.tgz * 
 mv package.tgz ../2_create_project/ 


### PR DESCRIPTION
After downloading, the gitea executable might not have its executable bit set. As it's required, building should take care of it.