### PR TITLE
Add Arch support

### DIFF
--- a/arch.desc
+++ b/arch.desc
@@ -1,0 +1,6 @@
+# Maps Gitea platforms to Synology arch values, see
+# https://developer.synology.com/developer-guide/appendix/index.html
+386 x86
+amd64 cedarview bromolow
+arm-5 88f6281 88f6282
+arm-7 armada370 armada375 armadaxp alpine/alpine4k comcerto2k

--- a/arch.desc
+++ b/arch.desc
@@ -1,6 +1,8 @@
 # Maps Gitea platforms to Synology arch values, see
 # https://developer.synology.com/developer-guide/appendix/index.html
+# https://github.com/SynologyOpenSource/pkgscripts-ng/blob/master/include/platforms
 386 x86
-amd64 cedarview bromolow
+amd64 cedarview bromolow denverton apollolake
 arm-5 88f6281 88f6282
 arm-7 armada370 armada375 armadaxp alpine/alpine4k comcerto2k
+arm64 rtd1296


### PR DESCRIPTION
As the packages are only suitable for certain platforms, the package metadata should reflect that and set the "arch" field according to the used Gitea binary