### PR TITLE
Added avoton processer for compatibility with DS1517+ and similar

### DIFF
--- a/arch.desc
+++ b/arch.desc
@@ -2,7 +2,7 @@
 # https://developer.synology.com/developer-guide/appendix/index.html
 # https://github.com/SynologyOpenSource/pkgscripts-ng/blob/master/include/platforms
 386 x86
-amd64 cedarview bromolow denverton apollolake
+amd64 cedarview bromolow denverton apollolake avoton
 arm-5 88f6281 88f6282
 arm-7 armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k monaco
 arm64 rtd1296


### PR DESCRIPTION
See https://www.synology.com/en-us/knowledgebase/DSM/tutorial/General/What_kind_of_CPU_does_my_NAS_have