### PR TITLE
Move arm7 to arm6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Gitea package requires the **[Git Server](https://www.synology.com/en-global
 
 To create the package, clone the repository:
 
-`$ git clone https://github.com/Kasurus/gitea-spk.git`
+`$ git clone https://github.com/flipswitchingmonkey/gitea-spk.git`
 
 Change into the newly created directory - the root directory:
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ The Gitea package requires the **[Git Server](https://www.synology.com/en-global
 
 To create the package, clone the repository:
 
-`$ git clone https://github.com/flipswitchingmonkey/gitea-spk.git`
+`$ git clone https://github.com/Kasurus/gitea-spk.git`
 
 Change into the newly created directory - the root directory:
 
 `$ cd gitea-spk`
 
-Download the Gitea binary matching your architecture from https://github.com/go-gitea/gitea/releases into the root directory. For example, a DiskStation with an ARMv7 CPU would require:
+Download the Gitea binary matching your architecture from https://github.com/go-gitea/gitea/releases into the root directory. For example, a DiskStation with an ARMv6 (or ARMv7) CPU would require:
 
-`$ wget https://github.com/go-gitea/gitea/releases/download/v1.1.4/gitea-1.1.4-linux-arm-7`
+`$ wget https://github.com/go-gitea/gitea/releases/download/v1.8.3/gitea-1.8.3-linux-arm-6`
 
 Invoke the build script to have the package created:
 
 `$ ./create_spk.sh`
 
-The install package matching your binary (here `gitea-1.1.4-linux-arm-7.spk`) will be created in the root directory.
+The install package matching your binary (here `gitea-1.8.3-linux-arm-6.spk`) will be created in the root directory.
 
 If you have several binaries downloaded, you can specify the binary for which the package should be created:
 
-`$ ./create_spk.sh gitea-1.1.3-linux-arm-7`
+`$ ./create_spk.sh gitea-1.8.3-linux-arm-6`
 
 ### Installation
 
@@ -44,7 +44,7 @@ When installation has finished, the package center shows url and status of your 
 
 When accessed for the first time, Gitea will greet you with the installation settings. You should set your **Repository Root Path** to a shared folder. You can configure permissions for shared folders in the control panel via **Edit > Permissions > System internal user** to grant the Gitea user permission.
 
-Tested to work on DS116 with Gitea 1.0.1.
+Tested to work on DS215j with Gitea v1.8.3 (arm-6).
 
 ### Acknowledgements
 

--- a/arch.desc
+++ b/arch.desc
@@ -4,6 +4,5 @@
 386 x86
 amd64 cedarview bromolow denverton apollolake avoton braswell grantley broadwell dockerx64 kvmx64 x64 
 arm-5 88f6281 88f6282
-arm-6 armada375 # temp-fix until gitea-arm-7 is working again
-arm-7 armada370 armada38x armadaxp alpine/alpine4k comcerto2k monaco
+arm-6 armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k monaco
 arm64 rtd1296

--- a/arch.desc
+++ b/arch.desc
@@ -4,5 +4,6 @@
 386 x86
 amd64 cedarview bromolow denverton apollolake avoton braswell grantley broadwell dockerx64 kvmx64 x64 
 arm-5 88f6281 88f6282
-arm-7 armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k monaco
+arm-6 armada375 # temp-fix until gitea-arm-7 is working again
+arm-7 armada370 armada38x armadaxp alpine/alpine4k comcerto2k monaco
 arm64 rtd1296


### PR DESCRIPTION
Since Gitea disabled arm7 builds in [v1.8.2](https://github.com/go-gitea/gitea/releases/tag/v1.8.2) all arm7 devices should use the arm6 builds.

I hope this is the right way to propose this change. I am fairly new to contributing. ;)